### PR TITLE
Remove unnecessary call to lambda function

### DIFF
--- a/hungarian.cc
+++ b/hungarian.cc
@@ -89,7 +89,6 @@ class HungarianOp : public OpKernel {
 
     auto worker_threads = context->device()->tensorflow_cpu_worker_threads();
     Shard(worker_threads->num_threads, worker_threads->workers, batch_size, single_cost, shard);
-    shard(0, batch_size);
   }
 };
 


### PR DESCRIPTION
I missed this in the previous commit.